### PR TITLE
Minor Style changes to bring up to PEP8 standard

### DIFF
--- a/a4/cif.py
+++ b/a4/cif.py
@@ -2,55 +2,68 @@ from dataclasses import dataclass
 from typing import List, Set, Dict, Tuple
 from cs202_support.base_ast import AST
 
+
 @dataclass
 class Atm(AST):
     pass
+
 
 @dataclass
 class Int(Atm):
     val: int
 
+
 @dataclass
 class Bool(Atm):
     val: bool
+
 
 @dataclass
 class Var(Atm):
     var: str
 
+
 @dataclass
 class Exp(AST):
     pass
 
+
 @dataclass
 class AtmExp(Exp):
     atm: Atm
+
 
 @dataclass
 class Prim(Exp):
     op: str
     args: List[Atm]
 
+
 @dataclass
 class Stmt(AST):
     pass
+
 
 @dataclass
 class Assign(Stmt):
     var: str
     exp: Exp
 
+
 @dataclass
 class Tail(AST):
     pass
+
 
 @dataclass
 class Return(Tail):
     exp: Exp
 
+
 @dataclass
 class Goto(Tail):
     label: str
+
 
 @dataclass
 class If(Tail):
@@ -58,10 +71,12 @@ class If(Tail):
     then_label: str
     else_label: str
 
+
 @dataclass
 class Seq(Tail):
     stmt: Stmt
     tail: Tail
+
 
 @dataclass
 class Program(AST):

--- a/a4/interpreter.py
+++ b/a4/interpreter.py
@@ -1,4 +1,4 @@
-from compiler import *
+from compiler import Dict, RifExp, Int, Bool, Var, Let, Prim, If
 
 binops = {
     '+': lambda a, b: a + b,
@@ -14,6 +14,7 @@ binops = {
 unops = {
     'not': lambda a: not a
     }
+
 
 def eval_rif(e: RifExp):
     def eval_e(e: RifExp, env: Dict[str, int]):

--- a/a4/rif_parser.py
+++ b/a4/rif_parser.py
@@ -8,21 +8,26 @@ from lark import Lark
 # Abstract Syntax Trees: Rif
 ##################################################
 
+
 @dataclass
 class RifExp(AST):
     pass
+
 
 @dataclass
 class Int(RifExp):
     val: int
 
+
 @dataclass
 class Bool(RifExp):
     val: bool
 
+
 @dataclass
 class Var(RifExp):
     var: str
+
 
 @dataclass
 class Let(RifExp):
@@ -30,10 +35,12 @@ class Let(RifExp):
     e1: RifExp
     body: RifExp
 
+
 @dataclass
 class Prim(RifExp):
     op: str
     args: List[RifExp]
+
 
 @dataclass
 class If(RifExp):
@@ -67,6 +74,7 @@ _r_var_parser = Lark(r"""
     %import common.WS
     %ignore WS
     """, start='exp', parser='lalr')
+
 
 ##################################################
 # Pass #0: Parsing Concrete to Abstract Syntax
@@ -103,6 +111,7 @@ def _parse(s: str) -> RifExp:
     parsed = _r_var_parser.parse(s)
     ast = bast(parsed)
     return ast
+
 
 def parse_rif(s):
     return _parse(s)

--- a/cs202_support/base_ast.py
+++ b/cs202_support/base_ast.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, fields
 
+
 class AST:
     pass
 

--- a/cs202_support/eval_x86.py
+++ b/cs202_support/eval_x86.py
@@ -3,6 +3,7 @@ from .parser_x86 import x86_parser, x86_parser_instrs
 
 import pandas as pd
 
+
 class X86Emulator:
     def __init__(self, logging=True):
         self.registers = defaultdict(lambda: None)
@@ -91,7 +92,7 @@ class X86Emulator:
             if d_orig[k] != d_after[k]:
                 keys_diff.append(k)
         return keys_diff
-        
+
     def print_state(self):
         memory = [[ f'mem {k}', self.memory[k] ] for k in self.memory.keys() ]
         registers = [[ f'reg {k}', self.registers[k] ] for k in self.registers.keys() ]
@@ -115,7 +116,6 @@ class X86Emulator:
         else:
             raise Exception('eval_imm: unknown immediate:', e)
 
-    
     def eval_arg(self, a):
         if a.data == 'reg_a':
             return self.registers[str(a.children[0])]
@@ -150,7 +150,7 @@ class X86Emulator:
 
     def eval_instrs(self, instrs, blocks, output):
         for instr in instrs:
-            #log('Evaluating instruction:', instr.pretty())
+            # log('Evaluating instruction:', instr.pretty())
             if instr.data == 'pushq':
                 a = instr.children[0]
                 self.registers['rsp'] = self.registers['rsp'] - 8
@@ -228,7 +228,6 @@ class X86Emulator:
                 else:
                     self.store_arg(a1, 0)
 
-
             elif instr.data == 'callq':
                 target = str(instr.children[0])
                 if target == 'print_int':
@@ -236,8 +235,6 @@ class X86Emulator:
                     output.append(self.registers['rdi'])
                     if self.logging:
                         print(self.print_state())
-
-
                 else:
                     self.eval_instrs(blocks[target], blocks, output)
 
@@ -260,7 +257,6 @@ class X86Emulator:
 
             else:
                 raise RuntimeError(f'Unknown instruction: {instr.data}')
-
 
 
 prog1 = """

--- a/cs202_support/parser_x86.py
+++ b/cs202_support/parser_x86.py
@@ -94,4 +94,3 @@ x86_parser_instrs = Lark(r"""
     %import common.WS
     %ignore WS
     """, start='instrs', parser='lalr')
-

--- a/cs202_support/r_int.py
+++ b/cs202_support/r_int.py
@@ -28,14 +28,17 @@ _r0_parser = Lark(r"""
 class RIntExp(AST):
     pass
 
+
 @dataclass
 class Int(RIntExp):
     val: int
+
 
 @dataclass
 class Plus(RIntExp):
     e1: RIntExp
     e2: RIntExp
+
 
 def parse(s):
     def bast(e):
@@ -48,6 +51,7 @@ def parse(s):
     parsed = _r0_parser.parse(s)
     ast = bast(parsed)
     return ast
+
 
 if __name__ == '__main__':
     e = Plus(Int(5), Int(6))

--- a/cs202_support/x86exp.py
+++ b/cs202_support/x86exp.py
@@ -8,100 +8,122 @@ from dataclasses import dataclass
 from typing import List, Set, Dict, Tuple, Any
 from .base_ast import AST
 
+
 # arg
 @dataclass(frozen=True, eq=True)
 class Arg(AST):
     pass
 
+
 @dataclass(frozen=True, eq=True)
 class Int(Arg):
     val: int
+
 
 @dataclass(frozen=True, eq=True)
 class Reg(Arg):
     val: str
 
+
 @dataclass(frozen=True, eq=True)
 class ByteReg(Arg):
     val: str
 
+
 @dataclass(frozen=True, eq=True)
 class Var(Arg):
     var: str
+
 
 @dataclass(frozen=True, eq=True)
 class Deref(Arg):
     offset: int
     val: str
 
+
 # instr
 @dataclass(frozen=True, eq=True)
 class Instr(AST):
     pass
+
 
 @dataclass(frozen=True, eq=True)
 class Addq(Instr):
     e1: Arg
     e2: Arg
 
+
 @dataclass(frozen=True, eq=True)
 class Subq(Instr):
     e1: Arg
     e2: Arg
 
+
 @dataclass(frozen=True, eq=True)
 class Negq(Instr):
     e1: Arg
+
 
 @dataclass(frozen=True, eq=True)
 class Movq(Instr):
     e1: Arg
     e2: Arg
 
+
 @dataclass(frozen=True, eq=True)
 class Cmpq(Instr):
     e1: Arg
     e2: Arg
+
 
 @dataclass(frozen=True, eq=True)
 class Xorq(Instr):
     e1: Arg
     e2: Arg
 
+
 @dataclass(frozen=True, eq=True)
 class Movzbq(Instr):
     e1: Arg
     e2: Arg
 
+
 @dataclass(frozen=True, eq=True)
 class Callq(Instr):
     label: str
 
+
 @dataclass(frozen=True, eq=True)
 class Jmp(Instr):
     label: str
+
 
 @dataclass(frozen=True, eq=True)
 class JmpIf(Instr):
     cc: str
     label: str
 
+
 @dataclass(frozen=True, eq=True)
 class Set(Instr):
     cc: str
     e1: Arg
 
+
 @dataclass(frozen=True, eq=True)
 class Pushq(Instr):
     e1: Arg
+
 
 @dataclass(frozen=True, eq=True)
 class Popq(Instr):
     e1: Arg
 
+
 @dataclass(frozen=True, eq=True)
 class Retq(Instr):
     pass
+
 
 @dataclass(frozen=True, eq=True)
 class Program(AST):


### PR DESCRIPTION
Some very minor changes to `cs202_support` and `a4` to bring various files up to PEP8 standard (pretty much only changed the number of whitespace between lines). If we do not want to follow this part of PEP8 I totally understand, it does make our language definition files quite a bit longer. I also changed the import statement in `a4`'s interpreter file to make the import explicit to follow PEP 20's "Explicit is better than implicit." mantra. 

Please comment/change/deny as you see fit!